### PR TITLE
Small UX updates

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -78,7 +78,11 @@ const App = () => {
 export default () => {
   return (
     <Router>
-      <ToastProvider autoDismiss={true} placement="bottom-center">
+      <ToastProvider
+        autoDismiss={true}
+        autoDismissTimeout={3000}
+        placement="bottom-center"
+      >
         <AuthProvider>
           <SidebarProvider>
             <App />

--- a/client/src/NewtWebApp.tsx
+++ b/client/src/NewtWebApp.tsx
@@ -59,7 +59,7 @@ const NewtWebApp = () => {
           <PrivateRoute
             Component={IndividualShelfPage}
             authExists={exists}
-            path="/shelves/:shelfName"
+            path={["/shelves/:shelfName/:contentId", "/shelves/:shelfName"]}
           />
           <PrivateRoute
             Component={ShelvesPage}

--- a/client/src/api/playlists.ts
+++ b/client/src/api/playlists.ts
@@ -1,5 +1,5 @@
 import newtApi from "./newtApi";
-import { useQuery, useMutation, queryCache } from "react-query";
+import { useQuery, useMutation, queryCache, MutationOptions } from "react-query";
 
 interface PlaylistData {
   name: string;
@@ -43,9 +43,10 @@ export function useFetchAllPlaylists() {
 export function useFetchPlaylist(playlistId: string) {
   return useQuery(["playlist", playlistId], fetchPlaylist);
 }
-export function useCreatePlaylist() {
+export function useCreatePlaylist(options?: MutationOptions<void, PlaylistData, Error, unknown> | undefined) {
   return useMutation(createPlaylist, {
     onSettled: () => queryCache.invalidateQueries("playlists"),
+    ...options
   });
 }
 export function useUpdatePlaylist() {

--- a/client/src/components/ContentCard/ContentCard.module.css
+++ b/client/src/components/ContentCard/ContentCard.module.css
@@ -57,6 +57,15 @@
   margin-bottom: 0.15rem;
 }
 
+.titleLink {
+  color: var(--gray-900);
+}
+
+.titleLink:hover {
+  text-decoration: underline;
+  color: var(--gray-900);
+}
+
 .smallTitle {
   font-size: var(--FS-s);
 }

--- a/client/src/components/ContentCard/index.tsx
+++ b/client/src/components/ContentCard/index.tsx
@@ -1,12 +1,20 @@
 import React from "react";
 import moment from "moment";
 import classnames from "classnames/bind";
-import styles from "./ContentCard.module.css";
+import { Link } from "react-router-dom";
 import { FiBook, FiPlusSquare } from "react-icons/fi";
+// Styling
+import styles from "./ContentCard.module.css";
 // Helpers
 import { shortenText } from "../../pages/Shelves/helpers";
 
 const cx = classnames.bind(styles);
+
+interface ContentCardTitleProps {
+  title: string;
+  size: "small" | "large";
+  titleLink?: string;
+}
 
 interface ContentCardProps {
   size: "small" | "large";
@@ -18,7 +26,28 @@ interface ContentCardProps {
   showAddToLibrary?: boolean;
   onClick?: () => void;
   onClickAddToLibrary?: () => void;
+  titleLink?: string; // Link to someplace once title is clicked
 }
+
+const ContentCardTitle = ({
+  title,
+  size,
+  titleLink,
+}: ContentCardTitleProps) => {
+  // If title is a link, render Link, otherwise just the title
+  return titleLink ? (
+    <Link to={titleLink} className={styles.titleLink}>
+      <h5 className={cx({ title: true, smallTitle: size === "small" })}>
+        {title}
+      </h5>
+    </Link>
+  ) : (
+    <h5 className={cx({ title: true, smallTitle: size === "small" })}>
+      {title}
+    </h5>
+  );
+};
+
 const ContentCard = ({
   size,
   showAddToLibrary,
@@ -29,6 +58,7 @@ const ContentCard = ({
   dateCompleted,
   onClick,
   onClickAddToLibrary,
+  titleLink,
 }: ContentCardProps) => {
   return (
     <div
@@ -56,9 +86,7 @@ const ContentCard = ({
             Otherwise just the title. */}
         {showAddToLibrary ? (
           <div className={styles.titleContainer}>
-            <h5 className={cx({ title: true, smallTitle: size === "small" })}>
-              {title}
-            </h5>
+            <ContentCardTitle title={title} size={size} titleLink={titleLink} />
             <div className={styles.addIconContainer}>
               <FiPlusSquare
                 size={22}
@@ -68,11 +96,8 @@ const ContentCard = ({
             </div>
           </div>
         ) : (
-          <h5 className={cx({ title: true, smallTitle: size === "small" })}>
-            {title}
-          </h5>
+          <ContentCardTitle title={title} size={size} titleLink={titleLink} />
         )}
-
         {authors ? (
           <p
             className={cx({ authors: true, smallAuthors: size === "small" })}

--- a/client/src/components/ContentInbox/index.tsx
+++ b/client/src/components/ContentInbox/index.tsx
@@ -2,7 +2,7 @@
 // details on right) -- used in Playlists/Shelves
 import React, { useState, useEffect } from "react";
 import _ from "lodash";
-import { useHistory } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import classnames from "classnames/bind";
 // Components
 import { FiArrowLeft } from "react-icons/fi";
@@ -54,8 +54,10 @@ const ContentInbox = ({
   const history = useHistory();
 
   const [currentContent, setCurrentContent] = useState<any>(null);
-
-  console.log(contentData);
+  // @ts-ignore
+  // Get contentId from route params, if it exists. This is used to set the inbox
+  // to the right content immediately, rather than always starting at the top
+  const { contentId } = useParams();
 
   // Okay there's this weird bug where the Inbox keeps moving to the first item
   // if I go to a different tab, or go off screen, or even open Inspector and close
@@ -65,11 +67,18 @@ const ContentInbox = ({
   // changes (does in Shelves, doesn't in Playlists??)
   useEffect(() => {
     if (!_.isEmpty(contentData)) {
-      setCurrentContent(contentData[0]);
+      // If a contentId exists as a URL parameter, use that to filter the data
+      // and jump to that specific item. If not, start at first one
+      if (contentId) {
+        const chosenContent = _.filter(contentData, { _id: contentId })[0];
+        setCurrentContent(chosenContent);
+      } else {
+        setCurrentContent(contentData[0]);
+      }
     } else {
       setCurrentContent(null);
     }
-  }, [contentData]);
+  }, [contentData, contentId]);
 
   return (
     <AppMainContainer variant="inbox" className={className}>

--- a/client/src/components/PrivateRoute/index.tsx
+++ b/client/src/components/PrivateRoute/index.tsx
@@ -4,7 +4,7 @@ import { RouteProps } from "react-router";
 
 interface PrivateRouteProps extends RouteProps {
   // https://stackoverflow.com/questions/53452966/typescript-3-jsx-element-type-component-does-not-have-any-construct-or-call-s?rq=1
-  Component: React.ReactType;
+  Component: React.ElementType;
   authExists: boolean;
 }
 
@@ -13,7 +13,16 @@ function PrivateRoute({ Component, authExists, ...rest }: PrivateRouteProps) {
     <Route
       {...rest}
       render={(props) =>
-        authExists ? <Component {...props} /> : <Redirect to="/login" />
+        authExists ? (
+          <Component {...props} />
+        ) : (
+          <Redirect
+            to={{
+              pathname: "/login",
+              state: { redirectTo: props.location },
+            }}
+          />
+        )
       }
     />
   );

--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -48,10 +48,13 @@ const removeAuthedUser = () => {
 };
 
 // Function to authenticate with Google
-export const authenticateWithGoogle = (dispatch) => (history) => {
+export const authenticateWithGoogle = (dispatch) => (
+  history,
+  redirectTo = "/dashboard"
+) => {
   // Get Google Provider
   const provider = new firebase.auth.GoogleAuthProvider();
-  authenticateWithProvider(provider, history, dispatch);
+  authenticateWithProvider(provider, history, dispatch, redirectTo);
 };
 
 // Function to authenticate with Google
@@ -63,7 +66,12 @@ export const authenticateWithGithub = (dispatch) => (history) => {
 
 // General function that uses Firebase authentication service (popup)
 // with a given auth provider
-async function authenticateWithProvider(provider, history, dispatch) {
+async function authenticateWithProvider(
+  provider,
+  history,
+  dispatch,
+  redirectTo
+) {
   firebase
     .auth()
     .signInWithPopup(provider)
@@ -88,7 +96,7 @@ async function authenticateWithProvider(provider, history, dispatch) {
       dispatch(setAuthedUser(res.data));
 
       // Redirect to dashboard
-      history.push("/dashboard");
+      history.push(redirectTo);
     })
     .catch((error) => {
       dispatch(removeAuthedUser());

--- a/client/src/pages/AddContent/index.tsx
+++ b/client/src/pages/AddContent/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import _ from "lodash";
+import { useToasts } from "react-toast-notifications";
 // API
 import {
   getYoutubeVideoInfo,
@@ -38,6 +39,9 @@ const AddContentPage = () => {
     OnConfirmationPageState
   >(null);
   const [youtubeContent, setYoutubeContent] = useState<any>(null);
+
+  // Toasts
+  const { addToast } = useToasts();
 
   const [
     addContent,
@@ -88,7 +92,18 @@ const AddContentPage = () => {
         finishDate
       );
 
-      await addContent(contentInfo);
+      await addContent(contentInfo, {
+        // Toast notifications on success and error
+        onSuccess: () =>
+          addToast("Video has been added to Shelves", {
+            appearance: "success",
+          }),
+        onError: () =>
+          addToast(
+            "Sorry, there was an error adding that video. Please try again.",
+            { appearance: "error" }
+          ),
+      });
 
       // Go back to form
       setOnConfirmationPage(null);
@@ -99,7 +114,18 @@ const AddContentPage = () => {
       const { seriesInfo } = values;
       const formattedSeriesInfo = extractAndAssemblePlaylistInfo(seriesInfo);
 
-      await createSeries(formattedSeriesInfo);
+      await createSeries(formattedSeriesInfo, {
+        // Toast notifications on success and error
+        onSuccess: () =>
+          addToast("Video series has been added to Shelves", {
+            appearance: "success",
+          }),
+        onError: () =>
+          addToast(
+            "Sorry, there was an error adding that video series. Please try again.",
+            { appearance: "error" }
+          ),
+      });
       // Go back to form
       setOnConfirmationPage(null);
       setYoutubeContent(null);
@@ -116,7 +142,20 @@ const AddContentPage = () => {
       finishDate
     );
 
-    await addContentV2(formattedBookInfo);
+    await addContentV2(formattedBookInfo, {
+      // Toast notifications on success and error
+      onSuccess: () =>
+        addToast(`${formattedBookInfo.name} added to Shelves`, {
+          appearance: "success",
+        }),
+      onError: () =>
+        addToast(
+          "Sorry, there was an error adding that book. Please try again.",
+          {
+            appearance: "error",
+          }
+        ),
+    });
   };
 
   if (addContentError) {

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -59,6 +59,7 @@ const Dashboard = () => {
               authors={item.authors}
               description={item.description}
               thumbnailUrl={item.thumbnailUrl}
+              titleLink={`/shelves/currently-learning/${item._id}`}
             />
           ))
         )}

--- a/client/src/pages/Landing/FeaturesSection.module.css
+++ b/client/src/pages/Landing/FeaturesSection.module.css
@@ -82,9 +82,15 @@
 .descriptionHeader#organize {
   color: var(--newtBlue-600);
 }
+.descriptionHeader#organize:hover {
+  color: var(--newtBlue-700);
+}
 
 .descriptionHeader#track {
   color: var(--hotPink-500);
+}
+.descriptionHeader#track:hover {
+  color: var(--hotPink-700);
 }
 
 .descriptionHeader#learn {

--- a/client/src/pages/Landing/FeaturesSection.tsx
+++ b/client/src/pages/Landing/FeaturesSection.tsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { MockPhone } from "./PhoneGraphic";
 import styles from "./FeaturesSection.module.css";
 
 interface FeatureProps {
   id: string;
   title: string;
+  linkTo?: string;
   description: React.ReactNode[];
   Graphic: React.ReactNode;
 }
@@ -13,6 +15,7 @@ const features = [
   {
     id: "organize",
     title: "Organize",
+    linkTo: "shelves",
     description: [
       "Everything you want to learn from \u2014 books, videos, articles, online courses, podcasts, interactive games, etc. \u2014 in one place.",
       <span>
@@ -30,6 +33,7 @@ const features = [
   {
     id: "track",
     title: "Track",
+    linkTo: "stats",
     description: [
       "Get stats on what you've read, watched, listened to, and played.",
       "Follow your progress over time.",
@@ -64,6 +68,7 @@ const features = [
   {
     id: "discover",
     title: "Discover",
+    linkTo: "discover",
     description: [
       "Why should recommendations be limited in the medium that they are in?",
       "After finishing a book, what if the best next thing is not another book, but a documentary? Or an interactive game?",
@@ -85,20 +90,20 @@ const features = [
   },
 ];
 
-const Feature = ({ id, title, description, Graphic }: FeatureProps) => {
+const Feature = ({ id, title, linkTo, description, Graphic }: FeatureProps) => {
   return (
     <div className={styles.feature}>
       <div id={styles[id]} className={styles.mockPhoneContainer}>
         {Graphic}
       </div>
       <div className={styles.descriptionContainer}>
-        {/* If title is Discover, link to page, otherwise just show title */}
-        {title === "Discover" ? (
-          <a href="discover">
+        {/* If link exists, link to page, otherwise just show title */}
+        {linkTo ? (
+          <Link to={linkTo}>
             <h2 id={styles[id]} className={`${styles.descriptionHeader}`}>
               {title}
             </h2>
-          </a>
+          </Link>
         ) : (
           <h2 id={styles[id]} className={`${styles.descriptionHeader}`}>
             {title}
@@ -122,6 +127,7 @@ const FeaturesSection = () => {
           <Feature
             id={feature.id}
             title={feature.title}
+            linkTo={feature?.linkTo}
             description={feature.description}
             key={feature.id}
             Graphic={

--- a/client/src/pages/Login/index.tsx
+++ b/client/src/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 // Context
 import { useData as useAuthData } from "../../context/AuthContext";
 // Components
@@ -12,6 +12,12 @@ import googleLogo from "../../assets/logos/googleLoginLogo";
 const LoginPage = () => {
   const { authenticateWithGoogle } = useAuthData();
   const history = useHistory();
+  // Destructuring from state throws type error, so setting as any
+  const location: any = useLocation();
+
+  // If there's a redirect path in state, use that. Otherwise default redirect
+  // after login is to Dashboard
+  const redirectTo = location.state?.redirectTo?.pathname || "/dashboard";
 
   return (
     <section>
@@ -24,7 +30,7 @@ const LoginPage = () => {
               <li className={styles.providerBtn}>
                 <Button
                   className={`${styles.loginBtn} ${styles.googleBtn}`}
-                  onClick={() => authenticateWithGoogle(history)}
+                  onClick={() => authenticateWithGoogle(history, redirectTo)}
                 >
                   <div className={styles.btnContent}>
                     {googleLogo}

--- a/client/src/pages/Shelves/Shelf.tsx
+++ b/client/src/pages/Shelves/Shelf.tsx
@@ -35,6 +35,7 @@ const Shelf = ({ id, name, data }: ShelfProps) => {
           .slice(0, 3)
           .map((item: any) => (
             <ShelfContentCard
+              contentId={item._id}
               key={item._id}
               name={item.name}
               thumbnailUrl={item.thumbnailUrl}

--- a/client/src/pages/Shelves/ShelfContentCard.module.css
+++ b/client/src/pages/Shelves/ShelfContentCard.module.css
@@ -12,6 +12,11 @@
   align-items: center;
 }
 
+.card:hover {
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.11), 0 8px 8px rgba(0, 0, 0, 0.14);
+  transition: all 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
 .card#currently-learning {
   background-color: var(--yellow-200);
 }

--- a/client/src/pages/Shelves/ShelfContentCard.tsx
+++ b/client/src/pages/Shelves/ShelfContentCard.tsx
@@ -1,27 +1,32 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import styles from "./ShelfContentCard.module.css";
 import { shortenText } from "./helpers";
 
 interface ShelfContentCardProps {
+  contentId: string;
   name: string;
   thumbnailUrl?: string;
   shelfId: "currently-learning" | "want-to-learn" | "finished-learning";
 }
 
 const ShelfContentCard = ({
+  contentId,
   name,
   thumbnailUrl,
   shelfId,
 }: ShelfContentCardProps) => {
   return (
-    <div className={styles.card} id={styles[shelfId]}>
-      <img
-        src={thumbnailUrl}
-        alt={`Thumbnail for ${name}`}
-        className={styles.thumbnail}
-      />
-      <div className={styles.name}>{shortenText(name, 30)}</div>
-    </div>
+    <Link to={`shelves/${shelfId}/${contentId}`}>
+      <div className={styles.card} id={styles[shelfId]}>
+        <img
+          src={thumbnailUrl}
+          alt={`Thumbnail for ${name}`}
+          className={styles.thumbnail}
+        />
+        <div className={styles.name}>{shortenText(name, 30)}</div>
+      </div>
+    </Link>
   );
 };
 

--- a/client/src/pages/UserPlaylists/PlaylistForm.tsx
+++ b/client/src/pages/UserPlaylists/PlaylistForm.tsx
@@ -22,19 +22,19 @@ interface PlaylistFormProps {
 
 const CHARACTER_LIMIT = 24;
 
+export const createPlaylistSchema = yup.object({
+  name: yup
+    .string()
+    .required("A playlist name is required.")
+    .max(CHARACTER_LIMIT),
+});
+
 const PlaylistForm = ({
   initialValues = { name: "" },
   onSubmit,
   buttonTitle = "Create",
   buttonCategory = "success",
 }: PlaylistFormProps) => {
-  const createPlaylistSchema = yup.object({
-    name: yup
-      .string()
-      .required("A playlist name is required.")
-      .max(CHARACTER_LIMIT),
-  });
-
   return (
     <Formik
       validationSchema={createPlaylistSchema}

--- a/client/src/pages/UserPlaylists/index.tsx
+++ b/client/src/pages/UserPlaylists/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import _ from "lodash";
+import { useToasts } from "react-toast-notifications";
 // API
 import { useFetchAllPlaylists, useCreatePlaylist } from "../../api/playlists";
 // Components
@@ -27,8 +28,16 @@ interface CreatePlaylistValues {
 
 const PlaylistsPage = () => {
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const { addToast } = useToasts();
+
   const { data, status, error } = useFetchAllPlaylists();
-  const [createPlaylist, { error: createPlaylistError }] = useCreatePlaylist();
+  const [createPlaylist, { error: createPlaylistError }] = useCreatePlaylist({
+    onSuccess: () => addToast("Playlist created", { appearance: "success" }),
+    onError: () =>
+      addToast("Sorry, there was an error creating the playlist", {
+        appearance: "error",
+      }),
+  });
 
   const handleCreatePlaylist = (values: CreatePlaylistValues) => {
     createPlaylist(values);


### PR DESCRIPTION
- Make Organize, Track, and Learn headings in Landing page links to App
- Those links are redirected to specific parts of App after logging in (if not already logged in)
- Create a new playlist straight from the 'Add to Playlist' modal/select
- The cards in each Shelf are now clickable and go to the specific content in the Shelf
- The title of cards in Dashboard are clickable and go to the shelf
- Success/error notifications for adding books/videos, creating playlists, and adding books/videos to playlists
